### PR TITLE
[MCC-177314] Integrate Rave deployment scripts into the workflow

### DIFF
--- a/conductor.ps1
+++ b/conductor.ps1
@@ -89,7 +89,6 @@ function Invoke-DeployWorkflow {
 
             itk -task unpack,config -role auto
             if (is-master) { itk -task unpack,config -role $db }
-            if (is-master) { validate-env-vars }
         }
 
         Invoke-RemoteScriptInParallel -sessions $sessions -script {

--- a/conductor.ps1
+++ b/conductor.ps1
@@ -64,7 +64,7 @@ function Get-NodeNames {
 $injectEnvironmentVariables = {
     # Set all environment variables based on the input JSON string
     $env:SITE_NAME="RaveProdTestSite"
-    $env:PACKAGE_DIR="\\hdcsharedmachine\packages\Rave\2015.2.0"
+    $env:PACKAGE_DIR="\\hdcsharedmachine\C$\packages\Rave\2015.2.0"
     $env:DEPLOY_ID ="yyyyMMddhhmmss-buildid"
     $env:RELEASE_DIR="C:\MedidataApp\Rave\Sites\$env:SITE_NAME\release\$env:DEPLOY_ID"
     $env:ARTIFACTS_DIR="C:\MedidataApp\Rave\Sites\$env:SITE_NAME\artifacts\$env:DEPLOY_ID"

--- a/conductor.ps1
+++ b/conductor.ps1
@@ -85,7 +85,9 @@ function Invoke-DeployWorkflow {
             Copy-Item "$env:PACKAGES_DIR\Medidata.AdminProcess.zip" -Destination "$env:ARTIFACTS_DIR"
 
             # 2. Unzip deployment script package
-            (new-object -com shell.application).namespace(\"$env:RELEASE_DIR\Medidata.AdminProcess\").CopyHere((new-object -com shell.application).namespace(\"$env:ARTIFACTS_DIR\Medidata.AdminProcess.zip\").Items(), 1556)
+            $shell = new-object -com shell.application
+            $zipFile = $shell.namespace("$env:ARTIFACTS_DIR\Medidata.AdminProcess.zip")
+            $shell.namespace("$env:RELEASE_DIR\Medidata.AdminProcess").CopyHere($zipFile.Items(), 1556)
 
             . $env:RELEASE_DIR\Medidata.AdminProcess\deploy_tasks_prod.ps1
 

--- a/conductor.ps1
+++ b/conductor.ps1
@@ -75,7 +75,8 @@ $installDeploymentScripts = {
     if (-not (Test-path $packagePath)) { throw "Cannot find path '$packagePath'" }
 
     # Download deployment script package
-    New-Item $artifactPath -type file -force
+    New-Item $releaseDir -type directory -force | Out-Null
+    New-Item $artifactPath -type file -force | Out-Null
     Copy-Item $packagePath $artifactPath -force
 
     # Unzip deployment script package
@@ -89,6 +90,7 @@ $installDeploymentScripts = {
 function Invoke-DeployWorkflow {
     $nodes = Get-NodeNames
     Init-Logfiles $nodes
+
     $sessions = New-PSSession -ComputerName $nodes
 
     try {

--- a/conductor.ps1
+++ b/conductor.ps1
@@ -86,7 +86,7 @@ function Invoke-DeployWorkflow {
             # Unzip deployment script package
             (new-object -com shell.application).namespace(\"$env:RELEASE_DIR\Medidata.AdminProcess\").CopyHere((new-object -com shell.application).namespace(\"$env:ARTIFACTS_DIR\Medidata.AdminProcess.zip\").Items(), 1556)
 
-            . $env:RELEASE_DIR\\Medidata.Installation\\deploy_tasks_prod.ps1
+            . $env:RELEASE_DIR\Medidata.Installation\deploy_tasks_prod.ps1
 
             itk -task download,unpack,config -role auto
             if (is-master) { itk -task download,unpack,config -role $db }

--- a/conductor.ps1
+++ b/conductor.ps1
@@ -86,7 +86,7 @@ function Invoke-DeployWorkflow {
             # Unzip deployment script package
             (new-object -com shell.application).namespace(\"$env:RELEASE_DIR\Medidata.AdminProcess\").CopyHere((new-object -com shell.application).namespace(\"$env:ARTIFACTS_DIR\Medidata.AdminProcess.zip\").Items(), 1556)
 
-            . $env:RELEASE_DIR\Medidata.Installation\deploy_tasks_prod.ps1
+            . $env:RELEASE_DIR\Medidata.AdminProcess\deploy_tasks_prod.ps1
 
             itk -task download,unpack,config -role auto
             if (is-master) { itk -task download,unpack,config -role $db }

--- a/conductor.ps1
+++ b/conductor.ps1
@@ -79,16 +79,17 @@ function Invoke-DeployWorkflow {
         Invoke-RemoteScriptInParallel -sessions $sessions -script $setupSession
         Invoke-RemoteScriptInParallel -sessions $sessions -script $injectEnvironmentVariables
         Invoke-RemoteScriptInParallel -sessions $sessions -script {
+            # Download deployment script package
             New-Item -path $env:ARTIFACTS_DIR -type directory
-            Copy-Item "$env:PACKAGES_DIR\*.zip" "$env:ARTIFACTS_DIR"
-            New-Item -path "$env:RELEASE_DIR\Medidata.AdminProcess" -type directory
-            # Unzip deployment scripts
-            (new-object -com shell.application).namespace(\"$env:RELEASE_DIR\\Medidata.AdminProcess\").CopyHere((new-object -com shell.application).namespace(\"$env:ARTIFACTS_DIR\\Medidata.AdminProcess.zip\").Items(), 1556)
+            Copy-Item "$env:PACKAGES_DIR\Medidata.AdminProcess.zip" -Destination "$env:ARTIFACTS_DIR"
+
+            # Unzip deployment script package
+            (new-object -com shell.application).namespace(\"$env:RELEASE_DIR\Medidata.AdminProcess\").CopyHere((new-object -com shell.application).namespace(\"$env:ARTIFACTS_DIR\Medidata.AdminProcess.zip\").Items(), 1556)
 
             . $env:RELEASE_DIR\\Medidata.Installation\\deploy_tasks_prod.ps1
 
-            itk -task unpack,config -role auto
-            if (is-master) { itk -task unpack,config -role $db }
+            itk -task download,unpack,config -role auto
+            if (is-master) { itk -task download,unpack,config -role $db }
         }
 
         Invoke-RemoteScriptInParallel -sessions $sessions -script {

--- a/conductor.ps1
+++ b/conductor.ps1
@@ -74,12 +74,10 @@ function Invoke-DeployWorkflow {
     $sessions = New-PSSession -ComputerName $nodes
 
     try {
-        Invoke-RemoteScriptInParallel -sessions $sessions -script {
-            # 0. Prepare node to run the Rave deployment scripts
-            & $replacewritehost
-            & $setupSession
-            & $injectEnvironmentVariables
-        }
+        # 0. Prepare node to run the Rave deployment scripts
+        Invoke-RemoteScriptInParallel -sessions $sessions -script $setupSession
+        Invoke-RemoteScriptInParallel -sessions $sessions -script $replacewritehost
+        Invoke-RemoteScriptInParallel -sessions $sessions -script $injectEnvironmentVariables
 
         Invoke-RemoteScriptInParallel -sessions $sessions -script {
             # 1. Download deployment script package

--- a/conductor.ps1
+++ b/conductor.ps1
@@ -14,7 +14,7 @@ function Get-LogDir {
 function Get-LogPath {
     param([string]$name)
 
-    (Get-LogDir)"\\$name.log"
+    return "$(Get-LogDir)\$($name).log"
 }
 
 function Init-LogFiles {
@@ -55,7 +55,7 @@ function Invoke-DeployPhase {
 
 function Get-NodeNames {
     $nodes = @("node1","node2")
-    return $nodes
+    return ,$nodes
 }
 
 $injectEnvironmentVariables = {
@@ -72,7 +72,7 @@ $installDeploymentScripts = {
     $artifactPath = "$env:ARTIFACTS_DIR\Medidata.AdminProcess.zip"
     $releaseDir = "$env:RELEASE_DIR\Medidata.AdminProcess"
 
-    if (-not (Test-path $packagePath)) throw "Cannot find path '$packagePath'"
+    if (-not (Test-path $packagePath)) { throw "Cannot find path '$packagePath'" }
 
     # Download deployment script package
     New-Item $artifactPath -type file -force

--- a/conductor.ps1
+++ b/conductor.ps1
@@ -3,7 +3,7 @@ param(
 )
 
 $setupSession = {
-    Set-ExecutionPolicy -ExecutionPolicy RemoteSigned
+    Set-ExecutionPolicy -ExecutionPolicy Unrestricted
     $DebugPreference = "continue"
 }
 

--- a/conductor.ps1
+++ b/conductor.ps1
@@ -5,7 +5,6 @@ param(
 $setupSession = {
     Set-ExecutionPolicy -ExecutionPolicy RemoteSigned
     $DebugPreference = "continue"
-    . C:\Github\Rave\Medidata.AdminProcess\deploy_tasks_dev.ps1
 }
 
 $replacewritehost = {

--- a/conductor.ps1
+++ b/conductor.ps1
@@ -61,7 +61,7 @@ $installDeploymentScripts = {
     $releaseDir = "$env:RELEASE_DIR\Medidata.AdminProcess"
 
     if (-not (Test-path $packagePath)) throw "Cannot find path '$packagePath'"
-    
+
     # Download deployment script package
     New-Item $artifactPath -type file -force
     Copy-Item $packagePath $artifactPath -force
@@ -107,7 +107,7 @@ function Invoke-DeployWorkflow {
         }
     }
     catch {
-        Write-Host "Something bad happened."
+        Write-Output "Something bad happened."
         Write-Error $_
     }
 


### PR DESCRIPTION
- [x] Added a hard-coded env var injecting function.
- [x] Added Rave deployment scripts into the workflow.
- [x] Removed `$replacewritehost` because Rave deployment script never uses `write-host`.

@echen-mdsol @vcapers-mdsol Please review and merge if OK. Thanks.